### PR TITLE
Temporarily remove external_id

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -251,10 +251,6 @@ ___TEMPLATE_PARAMETERS___
               {
                 "value": "idfa",
                 "displayValue": "IDFA"
-              },
-              {
-                "value": "externalId",
-                "displayValue": "External ID"
               }
             ],
             "isUnique": true,


### PR DESCRIPTION
This was a request since we aren't fully pushing the external-id option just yet. We don't need to adjust the underlying JS either, since it only coverts the Advanced Matching table to an object, without referencing by name.