### PR TITLE
hotfix: udpating help link in template documentation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.redditinc.com/advertising"
-documentation: "https://www.reddithelp.com/en/categories/advertising/creating-ads/conversion-pixel#N6"
+documentation: "https://advertising.reddithelp.com/en/categories/measurement/install-reddit-pixel#googleTM"
 versions:
   # Latest Version
   - sha: 0a115e6fa658a423fe4d8baaa7fe15f46f158598


### PR DESCRIPTION
Shirley caught that the template documentation help link was out of date.  Confirmed with Katie it should be https://advertising.reddithelp.com/en/categories/measurement/install-reddit-pixel#googleTM instead.