### PR TITLE
Bump metadata to deploy ad account a2_ prefix support

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.redditinc.com/advertising"
 documentation: "https://advertising.reddithelp.com/en/categories/measurement/install-reddit-pixel#googleTM"
 versions:
   # Latest Version
+  - sha: 99eabd9ee5d52d6bec26be397d93853a35581f29
+    changeNotes: This release includes support for ad accounts with a new id format.
+  # Older versions
   - sha: ff5c10db6ca695406b691e6f57777c4cd3d55205
     changeNotes: This release includes the ability to pass event metadata for revenue-related events (currency, value, item count, transaction ID).  It also allows for custom event types with a free-form name.
-  # Older versions
   - sha: 63b171eea243991d1bac1ccb68b9bd40cbea1740
     changeNotes: This release includes the ability to pass advanced matching parameters such as email addresses, MAIDs, or advertiser-assigned identifiers.
   - sha: 45e894256e4fb45a92195fb0e99e81e1208aee33


### PR DESCRIPTION
This includes #18.

I'm following the instructions in the README. This should rollout between a couple hours and a couple days.