### PR TITLE
[AME-3515] Update Reddit Install GTM documentation link

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.redditinc.com/advertising"
-documentation: "https://advertising.reddithelp.com/en/categories/measurement/install-reddit-pixel#googleTM"
+documentation: "https://reddit.my.site.com/helpcenter/s/article/Install-the-Reddit-Pixel-on-your-website"
 versions:
   # Latest Version
   - sha: 1c77a3a37d4f38ba422346a87a49b07e67289e55

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.redditinc.com/advertising"
-documentation: "https://reddit.my.site.com/helpcenter/s/article/Install-the-Reddit-Pixel-on-your-website"
+documentation: "https://reddit.my.site.com/helpcenter/s/article/Install-the-Reddit-Pixel-on-your-website#GTM"
 versions:
   # Latest Version
   - sha: 1c77a3a37d4f38ba422346a87a49b07e67289e55


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)
https://reddit.atlassian.net/browse/AME-3515
<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->
Just updating the documentation link for installing via GTM. The current URL (for me) goes to a HTML page that says the site no longer exists.

<img width="1509" alt="Screenshot 2023-12-14 at 3 18 04 PM" src="https://github.com/reddit/reddit-gtm-template/assets/86074040/d1fa1746-0cb0-4ca4-a2b8-c3bd9106d7c0">

Instead, we should link users to the new help pages for the Pixel
<img width="1490" alt="Screenshot 2023-12-14 at 3 19 16 PM" src="https://github.com/reddit/reddit-gtm-template/assets/86074040/d9e436eb-c90b-43e4-abcd-3b0d14937c3e">


## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
