### PR TITLE
Bump version for docs

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.redditinc.com/advertising"
 documentation: "https://reddit.my.site.com/helpcenter/s/article/Install-the-Reddit-Pixel-on-your-website#GTM"
 versions:
   # Latest Version
+  - sha: 5a94553314fcd1d515b553dc4e20c10143b1203a
+    changeNotes: This release corrects the documentation link for install instructions.
+  # Older versions
   - sha: 1c77a3a37d4f38ba422346a87a49b07e67289e55
     changeNotes: This release includes support to pass data processing parameters to each event. Data processing parameters will be used to determine how Reddit processes the data it receives from conversion events, eg it can be used to tag an event as LDU (Limited Data Use).
-  # Older versions
   - sha: 19629745821b7140315cf4c429625a91351b8b48
     changeNotes: This release includes support to pass a unique conversion ID that corresponds to a distinct conversion event. Conversion ID is used for deduplication and prevents the same conversion event from being processed more than once if it is sent multiple times.
   - sha: ef774bfd1338fab6caeab509708b502b6269d3a0


### PR DESCRIPTION
Updates metadata to publish changes in https://github.com/reddit/reddit-gtm-template/pull/31. This updates the broken documentation link for installation instructions.