### PR TITLE
AME-3223: update metadata for release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.redditinc.com/advertising"
 documentation: "https://reddit.my.site.com/helpcenter/s/article/Install-the-Reddit-Pixel-on-your-website#GTM"
 versions:
   # Latest Version
+  - sha: 7e693d37e7e656d662acbce9751427a9fb7797b5
+    changeNotes: This release changes references of Ad Account ID to Pixel ID.
+  # Older versions
   - sha: 5a94553314fcd1d515b553dc4e20c10143b1203a
     changeNotes: This release corrects the documentation link for install instructions.
-  # Older versions
   - sha: 1c77a3a37d4f38ba422346a87a49b07e67289e55
     changeNotes: This release includes support to pass data processing parameters to each event. Data processing parameters will be used to determine how Reddit processes the data it receives from conversion events, eg it can be used to tag an event as LDU (Limited Data Use).
   - sha: 19629745821b7140315cf4c429625a91351b8b48


### PR DESCRIPTION
Updates metadata to publish changes in https://github.com/reddit/reddit-gtm-template/pull/28 which changes references of "advertiserId" and "Ad Account ID" to "pixelId" and "Pixel ID".