### PR TITLE
[ACS-2436] Update tag template for AutoGTM

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -548,19 +548,13 @@ if (!_rdt.pixelId) {
   _rdt('init', data.id, initData);
 }
 
-const enableFirstPartyCookiesFromDataLayer = copyFromDataLayer("enableFirstPartyCookies");
-var enableFirstPartyCookies = data.enableFirstPartyCookies || enableFirstPartyCookiesFromDataLayer || (eventModel && eventModel.enableFirstPartyCookies);
+var enableFirstPartyCookies = data.enableFirstPartyCookies || copyFromDataLayer("enableFirstPartyCookies") || (eventModel && eventModel.enableFirstPartyCookies);
 if (!enableFirstPartyCookies) {
   _rdt('disableFirstPartyCookies');
 }
 
-const currencyFromDataLayer = copyFromDataLayer("currency");
-eventMetadata.currency = data.currency || currencyFromDataLayer || (eventModel && eventModel.currency);
-
-const valueFromDataLayer = copyFromDataLayer("transactionValue");
-eventMetadata.value = data.transactionValue || valueFromDataLayer || (eventModel && eventModel.transactionValue);
-
-
+eventMetadata.currency = data.currency || copyFromDataLayer("currency") || (eventModel && eventModel.currency);
+eventMetadata.value = data.transactionValue || copyFromDataLayer("transactionValue") || (eventModel && eventModel.transactionValue);
 
 // Try grabbing product metadata from dataLayer
 const productRowsFromDataLayer = copyFromDataLayer("productsRows") || (eventModel && eventModel.productsRows);
@@ -586,13 +580,11 @@ if (productRowsFromDataLayer && productRowsFromDataLayer.length) {
 
 // Certain events don't support certain params, so we conditionally set them
 if (data.eventType != "AddToCart" && data.eventType != "AddToWishlist") {
-  const transactionIdFromDataLayer = copyFromDataLayer("transactionId");
-  eventMetadata.transactionId = data.transactionId || transactionIdFromDataLayer || (eventModel && eventModel.transactionId);
+  eventMetadata.transactionId = data.transactionId || copyFromDataLayer("transactionId") || (eventModel && eventModel.transactionId);
 }
 
 if (data.eventType != "SignUp" && data.eventType != "Lead") {
-  const itemCountFromDataLayer = copyFromDataLayer("itemCount");
-  eventMetadata.itemCount = data.itemCount || itemCountFromDataLayer || (eventModel && eventModel.itemCount);
+  eventMetadata.itemCount = data.itemCount || copyFromDataLayer("itemCount") || (eventModel && eventModel.itemCount);
 }
 
 if (data.eventType == "Custom") {

--- a/template.tpl
+++ b/template.tpl
@@ -468,7 +468,6 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "TEXT",
     "name": "partner",
-    "displayName": "Integration Partner",
     "simpleValueType": true
   }
 ]


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

This PR updates the GTM template for the Automatic GTM project. For the Auto GTM project, we are installing the Reddit Pixel Tag on a user's GTM container and need make a few changes including: Passing back all event types, adding a new partner variable, and collecting metadata and advanced matching values directly from the dataLayer.

## 📜 Details
[Design Doc](https://docs.google.com/document/d/1rog2lo-CASxZkM3EHsOaScq6Ia8h5xmDJi894at7cuw/edit?tab=t.0#heading=h.pqsq8wmvsptm)

[Jira](https://reddit.atlassian.net/browse/ACS-2436)

There are some changes that we need to be able to make to passback data effectively for the auto-install process:
1. **Event mapping** - we want to passback any event type found on a GTM fire so that we can map it back to a Reddit standard conversion event downstream. To do so, the Event to Fire variable has been expanded to allow for built-in variables. This allows us to assign the built-in `{{Event}}` variable that GTM automatically populates. This change is noted by the `macrosInSelect` to `true` change for that parameter
2. **Adding a partner variable** - this new flow leverages the existing Tag template. As a result, we need a way to tell the difference between manual and automatic setups. Automatic setups will pass back a new partner variable value. We can then use this value internally to know that a GTM conversion event was sent via the automatic flow setup. GTM events without this value will be assumed to be the manual setup
3. **Passing back event data values** - To allow users to pass back event metadata and advanced matching values without having to create templated variables within the GTM UI, we can read the dataLayer directly. All metadata that we grab via `data.<metadata>` have been updated to also check for the metadata value using the `copyFromDataLayer` function. This will allow users to either have the templated variables or only add metadata to the dataLayer 

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

<img width="717" alt="Screenshot 2025-01-29 at 12 41 15 PM" src="https://github.com/user-attachments/assets/ec1203e8-d1a7-440a-82b5-88f176b47561" />
<img width="1503" alt="Screenshot 2025-01-30 at 9 53 39 AM" src="https://github.com/user-attachments/assets/9e96f3fe-1064-4786-b42a-7be9d03c3c81" />


## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->
- Passes all pre-existing tests
- New tests added for copying data from dataLayer and from eventModel
- E2E tested via test page and Reddit Pixel Helper - verified that I'm able to pass event data without having to template the variables in the GTM UI

dataLayer.push from test page
<img width="709" alt="Screenshot 2025-01-29 at 1 40 22 PM" src="https://github.com/user-attachments/assets/83b6d47c-97ef-4402-9d8c-38f19983f061" />

resulting RPH event fire
<img width="336" alt="Screenshot 2025-01-29 at 1 40 11 PM" src="https://github.com/user-attachments/assets/a649ff91-0622-4f8d-bf1e-7a18a1e0b46f" />

example of custom event fire

<img width="333" alt="Screenshot 2025-01-29 at 1 48 24 PM" src="https://github.com/user-attachments/assets/073ee1c1-d9cb-4a20-9f27-43964906c9fc" />

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
