### PR TITLE
Update UI for Integration Value

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -12,7 +12,7 @@ ___INFO___
   "displayName": "Reddit Pixel",
   "description": "By using the Reddit Conversion Pixel you agree to comply with and to be bound by the Reddit Advertiser Measurement Program Terms\n\nhttps://www.reddithelp.com/en/categories/advertising/policy-guideline",
   "securityGroups": [],
-  "id": "cvt_temp_public_id",
+  "id": "cvt_PBGZL",
   "type": "TAG",
   "version": 1,
   "brand": {
@@ -54,6 +54,13 @@ ___TEMPLATE_PARAMETERS___
     "name": "id",
     "type": "TEXT",
     "valueHint": "t2_***** or a2_*****"
+  },
+  {
+    "type": "TEXT",
+    "name": "partner",
+    "simpleValueType": true,
+    "displayName": "Integration",
+    "help": "This value is created and set by the automatic installation flow"
   },
   {
     "macrosInSelect": true,
@@ -468,11 +475,6 @@ ___TEMPLATE_PARAMETERS___
       }
     ],
     "groupStyle": "ZIPPY_CLOSED"
-  },
-  {
-    "type": "TEXT",
-    "name": "partner",
-    "simpleValueType": true
   }
 ]
 


### PR DESCRIPTION
Follow up to the discussion here in a previous PR: https://github.com/reddit/reddit-gtm-template/pull/36#discussion_r1934858785

This PR aims to add back the integration partner created as part of the 1-Click automatic install flow. We had hidden the field as not to confuse users, however, when the field gets added during the flow, the value is shown to users with no context as to what it is. Since the value will be shown anyway, we should update the UI to give users a bit more context about what it is.

BEFORE
<img width="1144" alt="Screenshot 2025-03-19 at 3 38 31 PM" src="https://github.com/user-attachments/assets/36d35fdc-5128-4a42-a787-6a1ca2ff35e8" />



AFTER
<img width="1083" alt="Screenshot 2025-03-19 at 3 50 48 PM" src="https://github.com/user-attachments/assets/804a5e18-be5a-4832-bfe5-e7c2fc44d864" />

<img width="1074" alt="Screenshot 2025-03-19 at 3 50 57 PM" src="https://github.com/user-attachments/assets/9cf26991-08fa-404a-8fcf-ac42b1ab3118" />


