### PR TITLE
Add support for p2 pixel IDs

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -44,7 +44,7 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "args": [
-          "(t2_|a2_)[a-z0-9]+"
+          "(t2_|a2_|p2_)[a-z0-9]+"
         ],
         "type": "REGEX"
       }
@@ -53,7 +53,7 @@ ___TEMPLATE_PARAMETERS___
     "simpleValueType": true,
     "name": "id",
     "type": "TEXT",
-    "valueHint": "t2_***** or a2_*****"
+    "valueHint": "t2_*****, a2_*****, or p2_*****"
   },
   {
     "type": "TEXT",


### PR DESCRIPTION
Adding support for the new pixel ID schema

Tested by copying the updated regex into the GTM template editor and sending test events to a p2_ prefixed pixel

<img width="935" height="499" alt="Screenshot 2026-06-30 at 12 31 59 PM" src="https://github.com/user-attachments/assets/ead60cb3-1fd1-44e8-9f92-186f7fc624b6" />
